### PR TITLE
5pm-3 Updated Links For Docs and Docs-QA in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 # Storybook
 
-* [Production](https://github.com/ucsb-cs156-s22/s22-5pm-happycows-docs)
-* [QA](https://github.com/ucsb-cs156-s22/s22-5pm-happycows-docs-qa)
+* [Production](https://ucsb-cs156-s22.github.io/s22-5pm-happycows-docs/)
+* [QA](https://ucsb-cs156-s22.github.io/s22-5pm-happycows-docs-qa/)
 
 # Heroku
 6pm-3:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 # Storybook
 
-* [Production](https://ucsb-cs156-w22.github.io/team04-w22-6pm-HappyCows-docs/)
-* [QA](https://ucsb-cs156-w22.github.io/team04-w22-6pm-HappyCows-docs-qa/)
+* [Production](https://github.com/ucsb-cs156-s22/s22-5pm-happycows-docs)
+* [QA](https://github.com/ucsb-cs156-s22/s22-5pm-happycows-docs-qa)
 
 # Heroku
 6pm-3:


### PR DESCRIPTION
Links in the README.md now point to the right deployed storybooks for docs and docs-qa.

Closes #1 