### PR TITLE
Add Entities and Respository for Leaderboard

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/LeaderboardController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/LeaderboardController.java
@@ -1,0 +1,93 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.annotations.Api;
+import lombok.extern.slf4j.Slf4j;
+
+@Api(description = "leaderboard")
+@RequestMapping("/api/leaderboard")
+@RestController
+@Slf4j
+public class LeaderboardController extends ApiController {
+
+    @Autowired
+    MenuItemReviewRepository menuItemReviewRepository;
+
+    @ApiOperation(value = "List all menu item reviews")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<MenuItemReview> allReviews() {
+        Iterable<MenuItemReview> reviews = menuItemReviewRepository.findAll();
+        return reviews;
+    }
+
+    @ApiOperation(value = "Get a single review")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public MenuItemReview getById(
+            @ApiParam("id of review to be viewed") @RequestParam Long id) {
+        MenuItemReview review = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        return review;
+    }
+
+    @ApiOperation(value = "Create a new review")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public MenuItemReview postReview(
+        @ApiParam("id of the menu item this is reviewing") @RequestParam Long itemId,
+        @ApiParam("email of the reviewer/critic") @RequestParam String reviewerEmail,
+        @ApiParam("number of stars (0-5)") @RequestParam int stars,
+        @ApiParam("date the menu item was reviewed YYYY-mm-ddTHH:MM:SS (Example: 2022-04-26T23:39:51)") @RequestParam LocalDateTime dateReviewed,
+        @ApiParam("review details") @RequestParam String comments
+        )
+        {
+
+        MenuItemReview review = new MenuItemReview();
+        review.setItemId(itemId);
+        review.setReviewerEmail(reviewerEmail);
+        review.setStars(stars);
+        review.setDateReviewed(dateReviewed);
+        review.setComments(comments);
+
+        MenuItemReview savedReview = menuItemReviewRepository.save(review);
+
+        return savedReview;
+    }
+
+    @ApiOperation(value = "Delete a MenuItemReview")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteReview(
+            @ApiParam("id of review to be deleted") @RequestParam Long id) {
+        MenuItemReview review = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        menuItemReviewRepository.delete(review);
+        return genericMessage("MenuItemReview with id %s deleted".formatted(id));
+    }
+
+    @ApiOperation(value = "Update a single review")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public MenuItemReview updateReview(
+            @ApiParam("id of review to be updated") @RequestParam Long id,
+            @RequestBody @Valid MenuItemReview incoming) {
+
+        MenuItemReview review = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        review.setItemId(incoming.getItemId());
+        review.setReviewerEmail(incoming.getReviewerEmail());
+        review.setStars(incoming.getStars());
+        review.setDateReviewed(incoming.getDateReviewed());
+        review.setComments(incoming.getComments());
+
+        menuItemReviewRepository.save(review);
+
+        return review;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Leaderboard.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Leaderboard.java
@@ -1,0 +1,29 @@
+package edu.ucsb.cs156.happiercows.entities;
+
+import javax.persistence.Entity;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import javax.persistence.GeneratedValue;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "leaderboard")
+public class Leaderboard {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String name;
+  private Integer cows;
+  private Long money;
+  private Long health;
+}
+

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/LeaderboardRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/LeaderboardRepository.java
@@ -1,0 +1,10 @@
+package edu.ucsb.cs156.happiercows.repositories;
+
+import edu.ucsb.cs156.happiercows.entities.Leaderboard;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface LeaderboardRepository extends CrudRepository<Leaderboard, Long> {
+}


### PR DESCRIPTION
# Overview

Added the backend table for Leaderboard. Leaderboard table has Player name, number of cows, amount of money, average cow health.

Might need to add something along the line with
`Optional<UserCommons> findByCommonsIdAndUserId(Long commonsId, Long userId );` in repository?

Doesn't close issue #9 fully. only partially.