### PR TITLE
s22-5pm-4 nw - added leaderboard bool field

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -86,7 +86,7 @@ public class CommonsController extends ApiController {
     updated.setMilkPrice(params.getMilkPrice());
     updated.setStartingBalance(params.getStartingBalance());
     updated.setStartingDate(params.getStartingDate());
-    updated.setShowLeaderboard(params.getShowLeaderboard());
+    updated.setLeaderboard(params.getLeaderboard());
 
     commonsRepository.save(updated);
 
@@ -118,7 +118,7 @@ public class CommonsController extends ApiController {
       .milkPrice(params.getMilkPrice())
       .startingBalance(params.getStartingBalance())
       .startingDate(params.getStartingDate())
-      .showLeaderboard(params.getShowLeaderboard())
+      .leaderboard(params.getLeaderboard())
       .build();
 
     Commons saved = commonsRepository.save(commons);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -86,7 +86,7 @@ public class CommonsController extends ApiController {
     updated.setMilkPrice(params.getMilkPrice());
     updated.setStartingBalance(params.getStartingBalance());
     updated.setStartingDate(params.getStartingDate());
-    updated.setLeaderboard(params.getLeaderboard());
+    updated.setShowLeaderboard(params.getShowLeaderboard());
 
     commonsRepository.save(updated);
 
@@ -118,7 +118,7 @@ public class CommonsController extends ApiController {
       .milkPrice(params.getMilkPrice())
       .startingBalance(params.getStartingBalance())
       .startingDate(params.getStartingDate())
-      .leaderboard(params.getLeaderboard())
+      .showLeaderboard(params.getShowLeaderboard())
       .build();
 
     Commons saved = commonsRepository.save(commons);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -86,6 +86,7 @@ public class CommonsController extends ApiController {
     updated.setMilkPrice(params.getMilkPrice());
     updated.setStartingBalance(params.getStartingBalance());
     updated.setStartingDate(params.getStartingDate());
+    updated.setLeaderboard(params.getLeaderboard());
 
     commonsRepository.save(updated);
 
@@ -117,6 +118,7 @@ public class CommonsController extends ApiController {
       .milkPrice(params.getMilkPrice())
       .startingBalance(params.getStartingBalance())
       .startingDate(params.getStartingDate())
+      .leaderboard(params.getLeaderboard())
       .build();
 
     Commons saved = commonsRepository.save(commons);

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -29,7 +29,7 @@ public class Commons
   private double milkPrice;
   private double startingBalance;
   private LocalDateTime startingDate;
-  private Boolean leaderboard;
+  private Boolean showLeaderboard;
 
   @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST,CascadeType.REMOVE})
   @JoinTable(name = "user_commons",

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -29,7 +29,7 @@ public class Commons
   private double milkPrice;
   private double startingBalance;
   private LocalDateTime startingDate;
-  private Boolean showLeaderboard;
+  private Boolean leaderboard;
 
   @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST,CascadeType.REMOVE})
   @JoinTable(name = "user_commons",

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -29,6 +29,7 @@ public class Commons
   private double milkPrice;
   private double startingBalance;
   private LocalDateTime startingDate;
+  private Boolean leaderboard;
 
   @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST,CascadeType.REMOVE})
   @JoinTable(name = "user_commons",

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -26,5 +26,6 @@ public class CreateCommonsParams
   @NumberFormat private double cowPrice;
   @NumberFormat private double milkPrice;
   @NumberFormat private double startingBalance;
+  private Boolean leaderboard;
   @DateTimeFormat private LocalDateTime startingDate;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -26,6 +26,6 @@ public class CreateCommonsParams
   @NumberFormat private double cowPrice;
   @NumberFormat private double milkPrice;
   @NumberFormat private double startingBalance;
-  private Boolean leaderboard;
+  private Boolean showLeaderboard;
   @DateTimeFormat private LocalDateTime startingDate;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -26,6 +26,6 @@ public class CreateCommonsParams
   @NumberFormat private double cowPrice;
   @NumberFormat private double milkPrice;
   @NumberFormat private double startingBalance;
-  private Boolean showLeaderboard;
+  private Boolean leaderboard;
   @DateTimeFormat private LocalDateTime startingDate;
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -72,7 +72,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
-      .leaderboard(true)
+      .showLeaderboard(true)
       .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -81,7 +81,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
-      .leaderboard(true)
+      .showLeaderboard(true)
       .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -135,7 +135,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
-      .leaderboard(true)
+      .showLeaderboard(true)
       .build();
 
     Commons commons = Commons.builder()
@@ -144,7 +144,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
-      .leaderboard(true)
+      .showLeaderboard(true)
       .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -374,7 +374,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .milkPrice(8.99)
         .startingBalance(1020.10)
         .startingDate(someTime)
-        .leaderboard(true)
+        .showLeaderboard(true)
         .build();
       
       when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -72,6 +72,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
+      .leaderboard(true)
       .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -80,6 +81,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
+      .leaderboard(true)
       .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -133,6 +135,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
+      .leaderboard(true)
       .build();
 
     Commons commons = Commons.builder()
@@ -141,6 +144,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
+      .leaderboard(true)
       .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -370,6 +374,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .milkPrice(8.99)
         .startingBalance(1020.10)
         .startingDate(someTime)
+        .leaderboard(true)
         .build();
       
       when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -72,7 +72,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
-      .showLeaderboard(true)
+      .leaderboard(true)
       .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -81,7 +81,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
-      .showLeaderboard(true)
+      .leaderboard(true)
       .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -135,7 +135,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
-      .showLeaderboard(true)
+      .leaderboard(true)
       .build();
 
     Commons commons = Commons.builder()
@@ -144,7 +144,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
-      .showLeaderboard(true)
+      .leaderboard(true)
       .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -374,7 +374,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .milkPrice(8.99)
         .startingBalance(1020.10)
         .startingDate(someTime)
-        .showLeaderboard(true)
+        .leaderboard(true)
         .build();
       
       when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));


### PR DESCRIPTION
# Overview

This PR adds boolean field "leaderboard" to the backend for Commons.


# Issues Addressed

This PR addresses issue #26 . The following files were changed to support a leaderboard field

Files Updated:
* Commons.java
* CreateCommonsParams.java
* CommonsController.java
* CommonsControllerTests.java
Note: none of the UserCommons fields or files were changed.

# Details

I added a "leaderboard" field to the Commons. It is a boolean value, which is true when the admins want to show leaderboard, and false if not. I haven't added that functionality, but that is the sentiment. I added the backend to be able to support a leaderboard.

This is what adding a commons looks like locally.
![image](https://user-images.githubusercontent.com/62904479/170789384-2bed7b03-a0a3-4e4c-beb3-f08676284af4.png)

Here is what it looks like on Heroku
![image](https://user-images.githubusercontent.com/62904479/170789449-97c26b14-e118-4b68-96b2-493cf7f01743.png)

And this is the /GET endpoint on heroku, after the post method
![image](https://user-images.githubusercontent.com/62904479/170789493-5ccba563-a2c2-419a-b989-74524c675074.png)


# Test Plan (for interactive testing)

To test this, rollback to my deployment on heroku, and naviagte to the swagger ui page. Then when you add a commons in the commons controller, there is a field for leaderboard.

