### PR TITLE
s22-5pm-3 Added backend functionality to query all UserCommons with specific commonsId

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ApiController.java
@@ -22,6 +22,18 @@ public abstract class ApiController {
   protected CurrentUser getCurrentUser() {
     return currentUserService.getCurrentUser();
   }
+
+  protected boolean hasRole(String role){
+    return currentUserService.hasRole(role);
+  }
+
+  protected boolean isAdmin(){
+    return currentUserService.isAdmin();
+  }
+
+  protected boolean isRegularUser(){
+    return currentUserService.isRegularUser();
+  }
   
   protected Object genericMessage(String message) {
     return Map.of("message", message);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ApiController.java
@@ -26,14 +26,6 @@ public abstract class ApiController {
   protected boolean hasRole(String role){
     return currentUserService.hasRole(role);
   }
-
-  protected boolean isAdmin(){
-    return currentUserService.isAdmin();
-  }
-
-  protected boolean isRegularUser(){
-    return currentUserService.isRegularUser();
-  }
   
   protected Object genericMessage(String message) {
     return Map.of("message", message);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -55,6 +55,19 @@ public class UserCommonsController extends ApiController {
     return userCommons;
   }
 
+  // Not sure what we should put for PreAuthorize.
+  // We need Admin to be able to call, but also if regular User visits Leaderboard and Admin has showLeaderboard set
+  // to true, then regular User should be able to call as well.
+  @ApiOperation(value = "Get all user commons with a specific commonsId")
+  @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
+  @GetMapping("/allWithCommonsId")
+  public Iterable<UserCommons> getUserCommonsByCommonsId(
+    @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
+      // we purposely don't check for a throw here, similar to UCSBDiningCommonsController
+      Iterable<UserCommons> userCommons = userCommonsRepository.findAllByCommonsId(commonsId);
+      return userCommons;
+  }
+
   @ApiOperation(value = "Get a user commons for current user")
   @PreAuthorize("hasRole('ROLE_USER')")
   @GetMapping("/forcurrentuser")

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -59,9 +59,9 @@ public class UserCommonsController extends ApiController {
   // We need Admin to be able to call, but also if regular User visits Leaderboard and Admin has showLeaderboard set
   // to true, then regular User should be able to call as well.
   @ApiOperation(value = "Get all user commons with a specific commonsId")
-  @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
-  @GetMapping("/allWithCommonsId")
-  public Iterable<UserCommons> getUserCommonsByCommonsId(
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/allwithcommonsid")
+  public Iterable<UserCommons> getAllUserCommonsByCommonsId(
     @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
       // we purposely don't check for a throw here, similar to UCSBDiningCommonsController
       Iterable<UserCommons> userCommons = userCommonsRepository.findAllByCommonsId(commonsId);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -68,7 +68,7 @@ public class UserCommonsController extends ApiController {
   public Iterable<UserCommons> getAllUserCommonsByCommonsId(
     @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
       // method inherited from ApiController
-      boolean isAdmin = isAdmin();
+      boolean isAdmin = hasRole("ROLE_ADMIN");
 
       Commons commons = commonsRepository.findById(commonsId)
         .orElseThrow(() -> new EntityNotFoundException(Commons.class, commonsId));

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -18,7 +18,10 @@ import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
+import edu.ucsb.cs156.happiercows.models.CurrentUser;
 import edu.ucsb.cs156.happiercows.controllers.ApiController;
+import edu.ucsb.cs156.happiercows.services.CurrentUserService;
+import edu.ucsb.cs156.happiercows.services.CurrentUserServiceImpl;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -64,15 +67,8 @@ public class UserCommonsController extends ApiController {
   @GetMapping("/allwithcommonsid")
   public Iterable<UserCommons> getAllUserCommonsByCommonsId(
     @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
-      boolean isAdmin = false;
-
-      for(GrantedAuthority a : getCurrentUser().getRoles()){
-        // comparing if they are equal does NOT work.
-        // could be padding issues?
-        if(a.getAuthority().contains("ROLE_ADMIN")){
-          isAdmin = true;
-        }
-      }
+      // method inherited from ApiController
+      boolean isAdmin = isAdmin();
 
       Commons commons = commonsRepository.findById(commonsId)
         .orElseThrow(() -> new EntityNotFoundException(Commons.class, commonsId));

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/UserCommonsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/UserCommonsRepository.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.happiercows.repositories;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.repository.CrudRepository;
@@ -10,6 +11,7 @@ import edu.ucsb.cs156.happiercows.entities.UserCommons;
 @Repository
 public interface UserCommonsRepository extends CrudRepository<UserCommons, Long> {
     Optional<UserCommons> findByCommonsIdAndUserId(Long commonsId, Long userId );
+    Iterable<UserCommons> findAllByCommonsId(Long commonsId);
 
     void deleteAllByCommonsId(Long commonsId);
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/CurrentUserService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/CurrentUserService.java
@@ -20,12 +20,6 @@ public abstract class CurrentUserService {
 
     return false;
   }
-  public boolean isAdmin(){
-    return hasRole("ROLE_ADMIN");
-  }
-  public boolean isRegularUser(){
-    return hasRole("ROLE_USER");
-  }
 
   public final boolean isLoggedIn() {
     return getUser() != null;

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/CurrentUserService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/CurrentUserService.java
@@ -11,6 +11,21 @@ public abstract class CurrentUserService {
   public abstract User getUser();
   public abstract CurrentUser getCurrentUser();
   public abstract Collection<? extends GrantedAuthority> getRoles();
+  public boolean hasRole(String role){
+    for(GrantedAuthority auth : getRoles()){
+      if(auth.getAuthority().contains(role)){
+        return true;
+      }
+    }
+
+    return false;
+  }
+  public boolean isAdmin(){
+    return hasRole("ROLE_ADMIN");
+  }
+  public boolean isRegularUser(){
+    return hasRole("ROLE_USER");
+  }
 
   public final boolean isLoggedIn() {
     return getUser() != null;

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -141,7 +141,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
     expectedCommons.addAll(Arrays.asList(dummyUserCommons(1), dummyUserCommons(2), dummyUserCommons(3)));
     when(userCommonsRepository.findAllByCommonsId(eq(1L))).thenReturn(expectedCommons);
 
-    MvcResult response = mockMvc.perform(get("/api/usercommons/allWithCommonsId?commonsId=1"))
+    MvcResult response = mockMvc.perform(get("/api/usercommons/allwithcommonsid?commonsId=1"))
         .andExpect(status().isOk()).andReturn();
 
     verify(userCommonsRepository, times(1)).findAllByCommonsId(eq(1L));
@@ -156,7 +156,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
     ArrayList<UserCommons> expectedCommons = new ArrayList<>();
     when(userCommonsRepository.findAllByCommonsId(eq(1L))).thenReturn(expectedCommons);
 
-    MvcResult response = mockMvc.perform(get("/api/usercommons/allWithCommonsId?commonsId=1"))
+    MvcResult response = mockMvc.perform(get("/api/usercommons/allwithcommonsid?commonsId=1"))
         .andExpect(status().isOk()).andReturn();
 
     verify(userCommonsRepository, times(1)).findAllByCommonsId(eq(1L));

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Optional;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -131,6 +132,37 @@ public class UserCommonsControllerTests extends ControllerTestCase {
     Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
     Map<String, Object> jsonResponse = responseToJson(response);
     assertEquals(expectedJson, jsonResponse);
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void test_getAllUserCommonsByCommonsId_some() throws Exception {
+    ArrayList<UserCommons> expectedCommons = new ArrayList<>();
+    expectedCommons.addAll(Arrays.asList(dummyUserCommons(1), dummyUserCommons(2), dummyUserCommons(3)));
+    when(userCommonsRepository.findAllByCommonsId(eq(1L))).thenReturn(expectedCommons);
+
+    MvcResult response = mockMvc.perform(get("/api/usercommons/allWithCommonsId?commonsId=1"))
+        .andExpect(status().isOk()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findAllByCommonsId(eq(1L));
+    String expectedJson = mapper.writeValueAsString(expectedCommons);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void test_getAllUserCommonsByCommonsId_none() throws Exception {
+    ArrayList<UserCommons> expectedCommons = new ArrayList<>();
+    when(userCommonsRepository.findAllByCommonsId(eq(1L))).thenReturn(expectedCommons);
+
+    MvcResult response = mockMvc.perform(get("/api/usercommons/allWithCommonsId?commonsId=1"))
+        .andExpect(status().isOk()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findAllByCommonsId(eq(1L));
+    String expectedJson = mapper.writeValueAsString(expectedCommons);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
   }
 
   @WithMockUser(roles = { "USER" })

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -188,6 +188,9 @@ public class UserCommonsControllerTests extends ControllerTestCase {
 
     verify(userCommonsRepository, times(1)).findAllByCommonsId(eq(1L));
     verify(commonsRepository, times(1)).findById(eq(1L));
+    String expectedJson = mapper.writeValueAsString(expectedCommons);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
   }
 
   // even if there are no userCommons with a specific commonsId,

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -194,7 +194,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
   // the backend shouldn't throw an error, just return empty list
   @WithMockUser(roles = { "ADMIN", "USER"})
   @Test
-  public void test_admin_getAllUserCommonsByCommonsId_none_exists_leaderboard_true() throws Exception {
+  public void test_getAllUserCommonsByCommonsId_none_exists_leaderboard_true() throws Exception {
     Commons testCommons = Commons
     .builder()
     .name("test commons")

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -124,7 +124,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
 
     MvcResult response = mockMvc.perform(get("/api/usercommons/forcurrentuser?commonsId=1"))
         .andExpect(status().is(404)).andReturn();
-
+    
     verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L),eq(1L));
     
     String responseString = response.getResponse().getContentAsString();
@@ -134,35 +134,163 @@ public class UserCommonsControllerTests extends ControllerTestCase {
     assertEquals(expectedJson, jsonResponse);
   }
 
-  @WithMockUser(roles = { "ADMIN", "USER" })
+  @WithMockUser(roles = { "ADMIN" })
   @Test
-  public void test_getAllUserCommonsByCommonsId_some() throws Exception {
+  public void test_admin_getAllUserCommonsByCommonsId_some_exists_leaderboard_true() throws Exception {
+
+    Commons testCommons = Commons
+    .builder()
+    .name("test commons")
+    .cowPrice(10)
+    .milkPrice(2)
+    .startingBalance(300)
+    .startingDate(LocalDateTime.now())
+    .leaderboard(true)
+    .build();
+
     ArrayList<UserCommons> expectedCommons = new ArrayList<>();
     expectedCommons.addAll(Arrays.asList(dummyUserCommons(1), dummyUserCommons(2), dummyUserCommons(3)));
     when(userCommonsRepository.findAllByCommonsId(eq(1L))).thenReturn(expectedCommons);
+    when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
 
     MvcResult response = mockMvc.perform(get("/api/usercommons/allwithcommonsid?commonsId=1"))
         .andExpect(status().isOk()).andReturn();
 
     verify(userCommonsRepository, times(1)).findAllByCommonsId(eq(1L));
+    verify(commonsRepository, times(1)).findById(eq(1L));
     String expectedJson = mapper.writeValueAsString(expectedCommons);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
   }
 
-  @WithMockUser(roles = { "ADMIN", "USER" })
+  // This tests to make sure leaderboard boolean won't affect access for 
+  // ADMIN user
+  @WithMockUser(roles = { "ADMIN" })
   @Test
-  public void test_getAllUserCommonsByCommonsId_none() throws Exception {
+  public void test_admin_getAllUserCommonsByCommonsId_some_exists_leaderboard_false() throws Exception {
+    Commons testCommons = Commons
+    .builder()
+    .name("test commons")
+    .cowPrice(10)
+    .milkPrice(2)
+    .startingBalance(300)
+    .startingDate(LocalDateTime.now())
+    .leaderboard(false)
+    .build();
+
     ArrayList<UserCommons> expectedCommons = new ArrayList<>();
+    expectedCommons.addAll(Arrays.asList(dummyUserCommons(1), dummyUserCommons(2), dummyUserCommons(3)));
     when(userCommonsRepository.findAllByCommonsId(eq(1L))).thenReturn(expectedCommons);
+    when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
 
     MvcResult response = mockMvc.perform(get("/api/usercommons/allwithcommonsid?commonsId=1"))
         .andExpect(status().isOk()).andReturn();
 
     verify(userCommonsRepository, times(1)).findAllByCommonsId(eq(1L));
+    verify(commonsRepository, times(1)).findById(eq(1L));
+  }
+
+  // even if there are no userCommons with a specific commonsId,
+  // the backend shouldn't throw an error, just return empty list
+  @WithMockUser(roles = { "ADMIN", "USER"})
+  @Test
+  public void test_admin_getAllUserCommonsByCommonsId_none_exists_leaderboard_true() throws Exception {
+    Commons testCommons = Commons
+    .builder()
+    .name("test commons")
+    .cowPrice(10)
+    .milkPrice(2)
+    .startingBalance(300)
+    .startingDate(LocalDateTime.now())
+    .leaderboard(true)
+    .build();
+
+    ArrayList<UserCommons> expectedCommons = new ArrayList<>();
+    when(userCommonsRepository.findAllByCommonsId(eq(1L))).thenReturn(expectedCommons);
+    when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+
+    MvcResult response = mockMvc.perform(get("/api/usercommons/allwithcommonsid?commonsId=1"))
+        .andExpect(status().isOk()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findAllByCommonsId(eq(1L));
+    verify(commonsRepository, times(1)).findById(eq(1L));
     String expectedJson = mapper.writeValueAsString(expectedCommons);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void test_user_getAllUserCommonsByCommonsId_some_exists_leaderboard_true() throws Exception {
+    Commons testCommons = Commons
+    .builder()
+    .name("test commons")
+    .cowPrice(10)
+    .milkPrice(2)
+    .startingBalance(300)
+    .startingDate(LocalDateTime.now())
+    .leaderboard(true)
+    .build();
+
+    ArrayList<UserCommons> expectedCommons = new ArrayList<>();
+    expectedCommons.addAll(Arrays.asList(dummyUserCommons(1), dummyUserCommons(2), dummyUserCommons(3)));
+    when(userCommonsRepository.findAllByCommonsId(eq(1L))).thenReturn(expectedCommons);
+    when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+
+    MvcResult response = mockMvc.perform(get("/api/usercommons/allwithcommonsid?commonsId=1"))
+        .andExpect(status().isOk()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findAllByCommonsId(eq(1L));
+    verify(commonsRepository, times(1)).findById(eq(1L));
+    String expectedJson = mapper.writeValueAsString(expectedCommons);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void test_user_getAllUserCommonsByCommonsId_some_exists_leaderboard_false() throws Exception {
+    Commons testCommons = Commons
+    .builder()
+    .name("test commons")
+    .cowPrice(10)
+    .milkPrice(2)
+    .startingBalance(300)
+    .startingDate(LocalDateTime.now())
+    .leaderboard(false)
+    .build();
+
+    ArrayList<UserCommons> expectedCommons = new ArrayList<>();
+    expectedCommons.addAll(Arrays.asList(dummyUserCommons(1), dummyUserCommons(2), dummyUserCommons(3)));
+    when(userCommonsRepository.findAllByCommonsId(eq(1L))).thenReturn(expectedCommons);
+    when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+
+    MvcResult response = mockMvc.perform(get("/api/usercommons/allwithcommonsid?commonsId=1"))
+        .andExpect(status().is(403)).andReturn();
+
+    verify(userCommonsRepository, times(0)).findAllByCommonsId(eq(1L));
+    verify(commonsRepository, times(1)).findById(eq(1L));
+  }
+
+  @WithMockUser(roles = { "USER", "ADMIN" })
+  @Test
+  public void test_getAllUserCommonsByCommonsId_commons_non_exist() throws Exception {
+    ArrayList<UserCommons> expectedCommons = new ArrayList<>();
+    expectedCommons.addAll(Arrays.asList(dummyUserCommons(1), dummyUserCommons(2), dummyUserCommons(3)));
+    when(userCommonsRepository.findAllByCommonsId(eq(1L))).thenReturn(expectedCommons);
+    when(commonsRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+    MvcResult response = mockMvc.perform(get("/api/usercommons/allwithcommonsid?commonsId=1"))
+        .andExpect(status().is(404)).andReturn();
+
+    verify(userCommonsRepository, times(0)).findAllByCommonsId(eq(1L));
+    verify(commonsRepository, times(1)).findById(eq(1L));
+    
+    String expectedString = "{\"message\":\"Commons with id 1 not found\",\"type\":\"EntityNotFoundException\"}";
+
+    Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+    Map<String, Object> jsonResponse = responseToJson(response);
+    assertEquals(expectedJson, jsonResponse);
   }
 
   @WithMockUser(roles = { "USER" })


### PR DESCRIPTION
# Overview

Adds functionality to the UserCommons backend to allow queries for all UserCommons with a specific commonsId. This allows the Leaderboard frontend to query this and display entries for all UserCommons with a specific commonsId. The sorting can then be done in the frontend.

This is what the new Swagger UI looks like

![Screen Shot 2022-05-31 at 10 02 40 AM](https://user-images.githubusercontent.com/58997326/171233514-20a5cda0-ac2c-4cae-81f7-00ea58a507ca.png)

EDIT: The backend route now also contains certain checks for access. There will be a valid response only if
- The User has the Admin role 
   OR
- The showLeaderboard field for the specific Commons is set to true.  

Otherwise, an AccessDeniedException will be thrown.  

Additionally, if the specific Commons being queried does not exist, an EntityNotFoundException will be thrown.

# Issues Addressed

Closes #9 

# Test Plan (for interactive testing)

You can test this by pulling this code onto your local and deploying it to localhost. From there, navigate to the Swagger UI and test the new query at the endpoint "/api/usercommons/allwithcommonsid