### PR TITLE
s22-5pm-4 - Kevin - Frontend Admin List Commons table add boolean show leaderboard field and make create, edit form have this boolean field also.

### DIFF
--- a/frontend/src/fixtures/commonsFixtures.js
+++ b/frontend/src/fixtures/commonsFixtures.js
@@ -10,6 +10,7 @@ const commonsFixtures = {
             "totalPlayers": 50,
             "cowPrice": 15,
             "milkPrice": 10,
+            "leaderboard": false,
         },
         {
             "id": 4,
@@ -21,6 +22,7 @@ const commonsFixtures = {
             "totalPlayers": 50,
             "cowPrice": 15,
             "milkPrice": 10,
+            "leaderboard": true,
         },
         {
             "id": 1,
@@ -32,6 +34,7 @@ const commonsFixtures = {
             "totalPlayers": 50,
             "cowPrice": 15,
             "milkPrice": 10,
+            "leaderboard": false,
         }
     ],
     oneCommons:
@@ -46,6 +49,7 @@ const commonsFixtures = {
                 "totalPlayers": 50,
                 "cowPrice": 15,
                 "milkPrice": 10,
+                "leaderboard": false,
             }
         ],
 

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -121,16 +121,16 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
       </Form.Group>
 
       <Form.Group className="mb-3">
-        <Form.Label htmlFor="showLeaderboard">Show Leaderboard</Form.Label>
+        <Form.Label htmlFor="leaderboard">Show Leaderboard</Form.Label>
         <Form.Check
-          data-testid={`${testid}-showLeaderboard`}
-          id="showLeaderboard"
+          data-testid={`${testid}-leaderboard`}
+          id="leaderboard"
           type="switch"
           // isInvalid={!!errors.showLeaderboard}
-          {...register("showLeaderboard", { required: "Boolean value is required" })}
+          {...register("leaderboard", { required: "Boolean value is required" })}
         />
         <Form.Control.Feedback type="invalid">
-          {errors.showLeaderboard?.message}
+          {errors.leaderboard?.message}
         </Form.Control.Feedback>
       </Form.Group>
 

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -126,8 +126,9 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
           data-testid={`${testid}-leaderboard`}
           id="leaderboard"
           type="switch"
-          // isInvalid={!!errors.showLeaderboard}
-          {...register("leaderboard", { required: "Boolean value is required" })}
+          isValid={true}
+          isInvalid={!!errors.showLeaderboard}
+          {...register("leaderboard")}
         />
         <Form.Control.Feedback type="invalid">
           {errors.leaderboard?.message}

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -119,6 +119,21 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
           {errors.startingDate?.message}
         </Form.Control.Feedback>
       </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="showLeaderboard">Show Leaderboard</Form.Label>
+        <Form.Check
+          data-testid={`${testid}-showLeaderboard`}
+          id="showLeaderboard"
+          type="switch"
+          // isInvalid={!!errors.showLeaderboard}
+          {...register("showLeaderboard", { required: "Boolean value is required" })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.showLeaderboard?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
       <Button type="submit" data-testid="CommonsForm-Submit-Button">{ buttonLabel }</Button>
     </Form>
   );

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -54,6 +54,11 @@ export default function CommonsTable({ commons, currentUser }) {
             //accessor: row => row.startingDate.toString(),
             accessor: row => String(row.startingDate),
             id: 'startingDate'
+        },
+        {
+            Header: 'Shows Leaderboard?',
+            accessor: row => String(row.leaderboard),
+            id: 'leaderboard'
         }
     ];
 

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -51,7 +51,6 @@ export default function CommonsTable({ commons, currentUser }) {
         },
         {
             Header:'Starting Date',
-            //accessor: row => row.startingDate.toString(),
             accessor: row => String(row.startingDate),
             id: 'startingDate'
         },

--- a/frontend/src/main/pages/AdminCreateCommonsPage.js
+++ b/frontend/src/main/pages/AdminCreateCommonsPage.js
@@ -15,7 +15,7 @@ const AdminCreateCommonsPage = () => {
     });
 
     const onSuccess = (commons) => {
-        toast(`Commons successfully created! - id: ${commons.id} name: ${commons.name} startDate: ${commons.startingDate} cowPrice: ${commons.cowPrice}`);
+        toast(`Commons successfully created! - id: ${commons.id} name: ${commons.name} startDate: ${commons.startingDate} cowPrice: ${commons.cowPrice} leaderboard: ${commons.leaderboard}`);
     }
    
     // Stryker disable all

--- a/frontend/src/main/pages/AdminEditCommonsPage.js
+++ b/frontend/src/main/pages/AdminEditCommonsPage.js
@@ -34,6 +34,7 @@ export default function CommonsEditPage() {
         "cowPrice": commons.cowPrice,
         "milkPrice": commons.milkPrice,
         "startingDate": commons.startingDate,
+        "leaderboard": commons.leaderboard
     }
   });
 

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -55,7 +55,6 @@ describe("CommonsForm tests", () => {
     expect(screen.getByText(/cow price is required/i)).toBeInTheDocument();
     expect(screen.getByText(/milk price is required/i)).toBeInTheDocument();
     expect(screen.getByText(/starting date is required/i)).toBeInTheDocument();
-    // expect(screen.getByBytext(/Boolean value is required/i)).toBeInTheDocument();
 
     expect(submitAction).not.toBeCalled();
   });

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -24,6 +24,7 @@ describe("CommonsForm tests", () => {
       /Cow Price/,
       /Milk Price/,
       /Starting Date/,
+      /Show Leaderboard/,
 
     ].forEach(
       (pattern) => {
@@ -54,6 +55,7 @@ describe("CommonsForm tests", () => {
     expect(screen.getByText(/cow price is required/i)).toBeInTheDocument();
     expect(screen.getByText(/milk price is required/i)).toBeInTheDocument();
     expect(screen.getByText(/starting date is required/i)).toBeInTheDocument();
+    // expect(screen.getByBytext(/Boolean value is required/i)).toBeInTheDocument();
 
     expect(submitAction).not.toBeCalled();
   });

--- a/frontend/src/tests/components/Commons/CommonsTable.test.js
+++ b/frontend/src/tests/components/Commons/CommonsTable.test.js
@@ -65,8 +65,8 @@ describe("UserTable tests", () => {
 
     );
 
-    const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date'];
-    const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate"];
+    const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date', 'Shows Leaderboard?'];
+    const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate", "leaderboard"];
     const testId = "CommonsTable";
 
     expectedHeaders.forEach((headerText) => {

--- a/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
@@ -106,6 +106,5 @@ describe("AdminCreateCommonsPage tests", () => {
         expect(axiosMock.history.post[0].data).toEqual( JSON.stringify(expectedCommons) );
 
         expect(mockToast).toBeCalledWith("Commons successfully created! - id: 5 name: My New Commons startDate: 2022-03-05T00:00:00 cowPrice: 10 leaderboard: true");
-        // expect(mockNavigate).toBeCalledWith({ "to": "/admin/listcommons" });
     });
 });

--- a/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
@@ -58,7 +58,8 @@ describe("AdminCreateCommonsPage tests", () => {
             "cowPrice": 10,
             "milkPrice": 5,
             "startingBalance": 500,
-            "startingDate": "2022-03-05T00:00:00"
+            "startingDate": "2022-03-05T00:00:00",
+            "leaderboard": true,
         });
 
         render(
@@ -76,6 +77,7 @@ describe("AdminCreateCommonsPage tests", () => {
         const cowPriceField = screen.getByLabelText("Cow Price");
         const milkPriceField = screen.getByLabelText("Milk Price");
         const startDateField = screen.getByLabelText("Starting Date");
+        const leaderboardField = screen.getByLabelText("Show Leaderboard");
         const button = screen.getByTestId("CommonsForm-Submit-Button");
 
         fireEvent.change(commonsNameField, { target: { value: 'My New Commons' } })
@@ -83,6 +85,7 @@ describe("AdminCreateCommonsPage tests", () => {
         fireEvent.change(cowPriceField, { target: { value: '10' } })
         fireEvent.change(milkPriceField, { target: { value: '5' } })
         fireEvent.change(startDateField, { target: { value: '2022-03-05' } })
+        fireEvent.change(leaderboardField, {target: { value: true}})
         fireEvent.click(button);
 
         await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
@@ -96,12 +99,13 @@ describe("AdminCreateCommonsPage tests", () => {
             startingBalance: 500,
             cowPrice: 10,
             milkPrice: 5,
-            startingDate: '2022-03-05T00:00:00.000Z' // [1]
+            startingDate: '2022-03-05T00:00:00.000Z', // [1]
+            leaderboard: true
         };
 
         expect(axiosMock.history.post[0].data).toEqual( JSON.stringify(expectedCommons) );
 
-        expect(mockToast).toBeCalledWith("Commons successfully created! - id: 5 name: My New Commons startDate: 2022-03-05T00:00:00 cowPrice: 10");
+        expect(mockToast).toBeCalledWith("Commons successfully created! - id: 5 name: My New Commons startDate: 2022-03-05T00:00:00 cowPrice: 10 leaderboard: true");
         // expect(mockNavigate).toBeCalledWith({ "to": "/admin/listcommons" });
     });
 });

--- a/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
@@ -85,7 +85,7 @@ describe("AdminCreateCommonsPage tests", () => {
         fireEvent.change(cowPriceField, { target: { value: '10' } })
         fireEvent.change(milkPriceField, { target: { value: '5' } })
         fireEvent.change(startDateField, { target: { value: '2022-03-05' } })
-        fireEvent.change(leaderboardField, {target: { value: true}})
+        fireEvent.change(leaderboardField, {target: { value: false}})
         fireEvent.click(button);
 
         await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
@@ -100,7 +100,7 @@ describe("AdminCreateCommonsPage tests", () => {
             cowPrice: 10,
             milkPrice: 5,
             startingDate: '2022-03-05T00:00:00.000Z', // [1]
-            leaderboard: true
+            leaderboard: false
         };
 
         expect(axiosMock.history.post[0].data).toEqual( JSON.stringify(expectedCommons) );

--- a/frontend/src/tests/pages/AdminEditCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminEditCommonsPage.test.js
@@ -46,7 +46,8 @@ describe("AdminEditCommonsPage tests", () => {
                 "startingDate": "2022-03-05",
                 "startingBalance": 1200,
                 "cowPrice": 15,
-                "milkPrice": 10
+                "milkPrice": 10,
+                "leaderboard": true
             });
             axiosMock.onPut('/api/commons/update').reply(200, {
                 "id": 5,
@@ -54,7 +55,8 @@ describe("AdminEditCommonsPage tests", () => {
                 "startingDate": "2022-03-07",
                 "startingBalance": 1400,
                 "cowPrice": 200,
-                "milkPrice": 5
+                "milkPrice": 5,
+                "leaderboard": false
             });
         });
 
@@ -85,12 +87,14 @@ describe("AdminEditCommonsPage tests", () => {
             const cowPriceField = screen.getByLabelText(/Cow Price/);
             const milkPriceField = screen.getByLabelText(/Milk Price/);
             const startingDateField = screen.getByLabelText(/Starting Date/);
+            const leaderboardField = screen.getByLabelText(/Show Leaderboard/);
 
             expect(nameField).toHaveValue("Seths Common");
             expect(startingDateField).toHaveValue("2022-03-05");
             expect(startingBalanceField).toHaveValue(1200);
             expect(cowPriceField).toHaveValue(15);
             expect(milkPriceField).toHaveValue(10);
+            expect(leaderboardField).toBeChecked()
         });
 
         test("Changes when you click Update", async () => {
@@ -109,12 +113,14 @@ describe("AdminEditCommonsPage tests", () => {
             const cowPriceField = screen.getByLabelText(/Cow Price/);
             const milkPriceField = screen.getByLabelText(/Milk Price/);
             const startingDateField = screen.getByLabelText(/Starting Date/);
+            const leaderboardField = screen.getByLabelText(/Show Leaderboard/);
 
             expect(nameField).toHaveValue("Seths Common");
             expect(startingDateField).toHaveValue("2022-03-05");
             expect(startingBalanceField).toHaveValue(1200);
             expect(cowPriceField).toHaveValue(15);
             expect(milkPriceField).toHaveValue(10);
+            expect(leaderboardField).toBeChecked();
 
             const submitButton = screen.getByText("Update");
 
@@ -125,6 +131,7 @@ describe("AdminEditCommonsPage tests", () => {
             fireEvent.change(startingBalanceField, { target: { value: 1400 } })
             fireEvent.change(cowPriceField, { target: { value: 200 } })
             fireEvent.change(milkPriceField, { target: { value: 5 } })
+            fireEvent.change(leaderboardField, { target: {value : false}})
 
             fireEvent.click(submitButton);
 
@@ -139,7 +146,8 @@ describe("AdminEditCommonsPage tests", () => {
                 "startingBalance": 1400,
                 "cowPrice": 200,
                 "milkPrice": 5,
-                "startingDate": "2022-03-07T00:00:00.000Z"
+                "startingDate": "2022-03-07T00:00:00.000Z",
+                "leaderboard": false
             })); // posted object
         });
     });

--- a/frontend/src/tests/pages/AdminEditCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminEditCommonsPage.test.js
@@ -131,7 +131,7 @@ describe("AdminEditCommonsPage tests", () => {
             fireEvent.change(startingBalanceField, { target: { value: 1400 } })
             fireEvent.change(cowPriceField, { target: { value: 200 } })
             fireEvent.change(milkPriceField, { target: { value: 5 } })
-            fireEvent.change(leaderboardField, { target: {value : false}})
+            fireEvent.change(leaderboardField, { target: {value : true}})
 
             fireEvent.click(submitButton);
 
@@ -147,7 +147,7 @@ describe("AdminEditCommonsPage tests", () => {
                 "cowPrice": 200,
                 "milkPrice": 5,
                 "startingDate": "2022-03-07T00:00:00.000Z",
-                "leaderboard": false
+                "leaderboard": true
             })); // posted object
         });
     });


### PR DESCRIPTION
# Overview

This PR tackles issue #24 and #28.

I added a column for the boolean value of displaying show leaderboard in the admin list commons page that has the edit functionality.

I updated the edit and create commons page to also include the boolean value for show leaderboard.

![image](https://user-images.githubusercontent.com/56693266/171291819-b7cc4ed6-5a5d-4c77-86b6-1410bcca047b.png)

![image](https://user-images.githubusercontent.com/56693266/171292060-523517c8-2afc-40fe-b9a3-635bcdc6a57c.png)

I also added the boolean leaderboard value to the fixtures so it shows up in the storybook.

![image](https://user-images.githubusercontent.com/56693266/171292349-684a868f-37f4-4a5e-9538-e41ba750c5ad.png)


Got 100% npm test coverage and passed stryker mutation testing.

![image](https://user-images.githubusercontent.com/56693266/171292178-403e2bc5-91c9-4942-b204-4b7fa810f889.png)

![image](https://user-images.githubusercontent.com/56693266/171292218-0da7786c-4f61-41a2-a64c-827013d478ef.png)
