### PR TITLE
s22-5pm-3 Added backend functionality for Admin to delete UserCommons by userId and commonsId

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -26,6 +26,7 @@ import javax.validation.Valid;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Api(description = "User Commons")
@@ -67,6 +68,20 @@ public class UserCommonsController extends ApiController {
         .orElseThrow(
             () -> new EntityNotFoundException(UserCommons.class, "commonsId", commonsId, "userId", userId));
     return userCommons;
+  }
+
+  @ApiOperation(value = "Delete a UserCommons")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteUserCommons(
+      @ApiParam("userId") @RequestParam Long userId,
+      @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException{
+    UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)
+        .orElseThrow(
+          () -> new EntityNotFoundException(UserCommons.class, "commonsId", commonsId, "userId", userId));
+    
+    userCommonsRepository.delete(userCommons);
+    return genericMessage("UserCommons with commonsId %s and userId %s deleted".formatted(commonsId, userId));
   }
 
   @ApiOperation(value = "Buy a cow, totalWealth updated")

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -762,6 +762,5 @@ public class UserCommonsControllerTests extends ControllerTestCase {
         assertEquals("UserCommons with commonsId 24 and userId 42 not found", json.get("message"));
     }
 
-    // perhaps add a test that makes sure users id and id of comons to delete are the same?
-    // is this necessary? is this possible?
+
 }


### PR DESCRIPTION
# Overview

Added an api endpoint for UserCommons that allows ADMINS to delete UserCommons by userId and commonsId. This could allows Admins to choose to remove players from a commons. NOTE, this only allows ADMINS to perform this action. Regular users themselves cannot remove themselves from a commons using this endpoint just yet.

# Issues Addressed

This PR closes #69 

# Details

This is what the new Swagger-UI looks like

![Screen Shot 2022-06-01 at 7 01 30 PM](https://user-images.githubusercontent.com/58997326/171531724-4ea92129-385d-431e-bf2c-4dfb474c976a.png)

This is what the Home page looks like BEFORE deleting the specified commons.
![Screen Shot 2022-06-01 at 7 04 22 PM](https://user-images.githubusercontent.com/58997326/171532436-1d425e59-4553-408a-b891-97a73f82bf57.png)

This is what the Home page looks like AFTER deleting the specified commons.
![Screen Shot 2022-06-01 at 7 06 32 PM](https://user-images.githubusercontent.com/58997326/171532622-515a267b-849a-4ecd-aa9c-05c32b1349f0.png)


# Test Plan (for interactive testing)

You can test this PR out by deploying this branch on localhost, logging in as an admin, creating a few commons and joining them, then visiting the swagger ui and using the delete endpoint to delete some of them. Going back to the home page on localhost, you should no longer see the deleted user commons under the "Visit a Commons" header.
