### PR TITLE
s22-5pm-3: Aashay - Adding Leaderboard Storybook, stories.js files, and LeaderboardFixtures file

### DIFF
--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -1,89 +1,85 @@
-const leaderboardFixtures =
-{
-    oneLeaderboardThreeEntries: 
-    [
-        {
-            "id": 1, 
-            "commonsId": 1, 
-            "userId": 1, 
-            "totalWealth": 1000000,
-            "numOfCows": 1000, 
-            "averageCowHealth": 85.0
-        }, 
-        {
-            "id": 2, 
-            "commonsId": 1, 
-            "userId": 14, 
-            "totalWealth": 10000, 
-            "numOfCows": 980, 
-            "averageCowHealth": 75.0
-        }, 
-        {
-            "id": 3, 
-            "commonsId": 1, 
-            "userId": 4, 
-            "totalWealth": 9999, 
-            "numOfCows": 875, 
-            "averageCowHealth": 90.0
-        }
-    ], 
+export const oneLeaderboardThreeEntries = 
+[
+    {
+        "id": 1, 
+        "commonsId": 1, 
+        "userId": 1, 
+        "totalWealth": 1000000,
+        "numOfCows": 1000, 
+        "averageCowHealth": 85.0
+    }, 
+    {
+        "id": 2, 
+        "commonsId": 1, 
+        "userId": 14, 
+        "totalWealth": 10000, 
+        "numOfCows": 980, 
+        "averageCowHealth": 75.0
+    }, 
+    {
+        "id": 3, 
+        "commonsId": 1, 
+        "userId": 4, 
+        "totalWealth": 9999, 
+        "numOfCows": 875, 
+        "averageCowHealth": 90.0
+    }
+]; 
 
-    oneLeaderboardOneEntry: 
-    [
-        {
-            "id": 1, 
-            "commonsId": 5, 
-            "userId": 1, 
-            "totalWealth": 1000000,
-            "numOfCows": 1000, 
-            "averageCowHealth": 68.0
-        }
-    ], 
+export const oneLeaderboardOneEntry = 
+[
+    {
+        "id": 1, 
+        "commonsId": 5, 
+        "userId": 1, 
+        "totalWealth": 1000000,
+        "numOfCows": 1000, 
+        "averageCowHealth": 68.0
+    }
+];
     
-    oneLeaderboardFiveEntries: 
-    [
-        {
-            "id": 1, 
-            "commonsId": 22, 
-            "userId": 23, 
-            "totalWealth": 150000,
-            "numOfCows": 1000, 
-            "averageCowHealth": 78.0
-        }, 
-        {
-            "id": 2, 
-            "commonsId": 22, 
-            "userId": 45, 
-            "totalWealth": 1000,
-            "numOfCows": 56, 
-            "averageCowHealth": 100.0
-        }, 
-        {
-            "id": 3, 
-            "commonsId": 22, 
-            "userId": 11, 
-            "totalWealth": 500,
-            "numOfCows": 23, 
-            "averageCowHealth": 100.0
-        }, 
-        {
-            "id": 4, 
-            "commonsId": 22, 
-            "userId": 21, 
-            "totalWealth": 56700,
-            "numOfCows": 450, 
-            "averageCowHealth": 92.0
-        }, 
-        {
-            "id": 5, 
-            "commonsId": 22, 
-            "userId": 9, 
-            "totalWealth": 10000000,
-            "numOfCows": 1000000, 
-            "averageCowHealth": 45.0
-        }
-    ]
-}; 
+export const oneLeaderboardFiveEntries = 
+[
+    {
+        "id": 1, 
+        "commonsId": 22, 
+        "userId": 23, 
+        "totalWealth": 150000,
+        "numOfCows": 1000, 
+        "averageCowHealth": 78.0
+    }, 
+    {
+        "id": 2, 
+        "commonsId": 22, 
+        "userId": 45, 
+        "totalWealth": 1000,
+        "numOfCows": 56, 
+        "averageCowHealth": 100.0
+    }, 
+    {
+        "id": 3, 
+        "commonsId": 22, 
+        "userId": 11, 
+        "totalWealth": 500,
+        "numOfCows": 23, 
+        "averageCowHealth": 100.0
+    }, 
+    {
+        "id": 4, 
+        "commonsId": 22, 
+        "userId": 21, 
+        "totalWealth": 56700,
+        "numOfCows": 450, 
+        "averageCowHealth": 92.0
+    }, 
+    {
+        "id": 5, 
+        "commonsId": 22, 
+        "userId": 9, 
+        "totalWealth": 10000000,
+        "numOfCows": 1000000, 
+        "averageCowHealth": 45.0
+    }
+];
 
-export { leaderboardFixtures };
 

--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -39,20 +39,51 @@ const leaderboardFixtures =
             //,"averageCowHealth": 98.0
         }
     ], 
+    
+    oneLeaderboardFiveEntries: 
+    [
+        {
+            "id": 1, 
+            "commonsId": 22, 
+            "userId": 23, 
+            "totalWealth": 150000,
+            "numOfCows": 1000
+            //,"averageCowHealth": 98.0
+        }, 
+        {
+            "id": 2, 
+            "commonsId": 22, 
+            "userId": 45, 
+            "totalWealth": 1000,
+            "numOfCows": 56
+            //,"averageCowHealth": 98.0
+        }, 
+        {
+            "id": 3, 
+            "commonsId": 22, 
+            "userId": 11, 
+            "totalWealth": 500,
+            "numOfCows": 23
+            //,"averageCowHealth": 98.0
+        }, 
+        {
+            "id": 4, 
+            "commonsId": 22, 
+            "userId": 21, 
+            "totalWealth": 56700,
+            "numOfCows": 450
+            //,"averageCowHealth": 98.0
+        }, 
+        {
+            "id": 5, 
+            "commonsId": 22, 
+            "userId": 9, 
+            "totalWealth": 10000000,
+            "numOfCows": 1000000
+            //,"averageCowHealth": 98.0
+        }
+    ]
 }; 
 
 export { leaderboardFixtures };
 
-
-// @GeneratedValue(strategy = GenerationType.IDENTITY)
-// private long id;  
-
-// @Column(name="commons_id")
-// private long commonsId;  
-
-// @Column(name="user_id")
-// private long userId;  
-
-// private double totalWealth;
-
-// private int numOfCows;

--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -8,7 +8,7 @@ const leaderboardFixtures =
             "userId": 1, 
             "totalWealth": 1000000,
             "numOfCows": 1000
-            //,"averageCowHealth": 98.0
+            //,"averageCowHealth": 85.0
         }, 
         {
             "id": 2, 
@@ -16,7 +16,7 @@ const leaderboardFixtures =
             "userId": 14, 
             "totalWealth": 10000, 
             "numOfCows": 980
-            //,"averageCowHealth": 94,0
+            //,"averageCowHealth": 75,0
         }, 
         {
             "id": 3, 
@@ -24,7 +24,7 @@ const leaderboardFixtures =
             "userId": 4, 
             "totalWealth": 9999, 
             "numOfCows": 875
-            //,"averageCowHealth": 85.0
+            //,"averageCowHealth": 90.0
         }
     ], 
 
@@ -36,7 +36,7 @@ const leaderboardFixtures =
             "userId": 1, 
             "totalWealth": 1000000,
             "numOfCows": 1000
-            //,"averageCowHealth": 98.0
+            //,"averageCowHealth": 68.0
         }
     ], 
     
@@ -48,7 +48,7 @@ const leaderboardFixtures =
             "userId": 23, 
             "totalWealth": 150000,
             "numOfCows": 1000
-            //,"averageCowHealth": 98.0
+            //,"averageCowHealth": 78.0
         }, 
         {
             "id": 2, 
@@ -56,7 +56,7 @@ const leaderboardFixtures =
             "userId": 45, 
             "totalWealth": 1000,
             "numOfCows": 56
-            //,"averageCowHealth": 98.0
+            //,"averageCowHealth": 100.0
         }, 
         {
             "id": 3, 
@@ -64,7 +64,7 @@ const leaderboardFixtures =
             "userId": 11, 
             "totalWealth": 500,
             "numOfCows": 23
-            //,"averageCowHealth": 98.0
+            //,"averageCowHealth": 100.0
         }, 
         {
             "id": 4, 
@@ -72,7 +72,7 @@ const leaderboardFixtures =
             "userId": 21, 
             "totalWealth": 56700,
             "numOfCows": 450
-            //,"averageCowHealth": 98.0
+            //,"averageCowHealth": 92.0
         }, 
         {
             "id": 5, 
@@ -80,7 +80,7 @@ const leaderboardFixtures =
             "userId": 9, 
             "totalWealth": 10000000,
             "numOfCows": 1000000
-            //,"averageCowHealth": 98.0
+            //,"averageCowHealth": 45.0
         }
     ]
 }; 

--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -1,0 +1,58 @@
+const leaderboardFixtures =
+{
+    oneLeaderboardThreeEntries: 
+    [
+        {
+            "id": 1, 
+            "commonsId": 1, 
+            "userId": 1, 
+            "totalWealth": 1000000,
+            "numOfCows": 1000
+            //,"averageCowHealth": 98.0
+        }, 
+        {
+            "id": 2, 
+            "commonsId": 1, 
+            "userId": 14, 
+            "totalWealth": 10000, 
+            "numOfCows": 980
+            //,"averageCowHealth": 94,0
+        }, 
+        {
+            "id": 3, 
+            "commonsId": 1, 
+            "userId": 4, 
+            "totalWealth": 9999, 
+            "numOfCows": 875
+            //,"averageCowHealth": 85.0
+        }
+    ], 
+
+    oneLeaderboardOneEntry: 
+    [
+        {
+            "id": 1, 
+            "commonsId": 5, 
+            "userId": 1, 
+            "totalWealth": 1000000,
+            "numOfCows": 1000
+            //,"averageCowHealth": 98.0
+        }
+    ], 
+}; 
+
+export { leaderboardFixtures };
+
+
+// @GeneratedValue(strategy = GenerationType.IDENTITY)
+// private long id;  
+
+// @Column(name="commons_id")
+// private long commonsId;  
+
+// @Column(name="user_id")
+// private long userId;  
+
+// private double totalWealth;
+
+// private int numOfCows;

--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -8,7 +8,6 @@ const leaderboardFixtures =
             "userId": 1, 
             "totalWealth": 1000000,
             "numOfCows": 1000
-            //,"averageCowHealth": 85.0
         }, 
         {
             "id": 2, 
@@ -16,7 +15,6 @@ const leaderboardFixtures =
             "userId": 14, 
             "totalWealth": 10000, 
             "numOfCows": 980
-            //,"averageCowHealth": 75,0
         }, 
         {
             "id": 3, 
@@ -24,7 +22,6 @@ const leaderboardFixtures =
             "userId": 4, 
             "totalWealth": 9999, 
             "numOfCows": 875
-            //,"averageCowHealth": 90.0
         }
     ], 
 
@@ -36,7 +33,6 @@ const leaderboardFixtures =
             "userId": 1, 
             "totalWealth": 1000000,
             "numOfCows": 1000
-            //,"averageCowHealth": 68.0
         }
     ], 
     
@@ -48,7 +44,6 @@ const leaderboardFixtures =
             "userId": 23, 
             "totalWealth": 150000,
             "numOfCows": 1000
-            //,"averageCowHealth": 78.0
         }, 
         {
             "id": 2, 
@@ -56,7 +51,6 @@ const leaderboardFixtures =
             "userId": 45, 
             "totalWealth": 1000,
             "numOfCows": 56
-            //,"averageCowHealth": 100.0
         }, 
         {
             "id": 3, 
@@ -64,7 +58,6 @@ const leaderboardFixtures =
             "userId": 11, 
             "totalWealth": 500,
             "numOfCows": 23
-            //,"averageCowHealth": 100.0
         }, 
         {
             "id": 4, 
@@ -72,7 +65,6 @@ const leaderboardFixtures =
             "userId": 21, 
             "totalWealth": 56700,
             "numOfCows": 450
-            //,"averageCowHealth": 92.0
         }, 
         {
             "id": 5, 
@@ -80,7 +72,6 @@ const leaderboardFixtures =
             "userId": 9, 
             "totalWealth": 10000000,
             "numOfCows": 1000000
-            //,"averageCowHealth": 45.0
         }
     ]
 }; 

--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -7,24 +7,24 @@ const leaderboardFixtures =
             "commonsId": 1, 
             "userId": 1, 
             "totalWealth": 1000000,
-            "numOfCows": 1000
-            //,"averageCowHealth": 85.0
+            "numOfCows": 1000, 
+            "averageCowHealth": 85.0
         }, 
         {
             "id": 2, 
             "commonsId": 1, 
             "userId": 14, 
             "totalWealth": 10000, 
-            "numOfCows": 980
-            //,"averageCowHealth": 75,0
+            "numOfCows": 980, 
+            "averageCowHealth": 75.0
         }, 
         {
             "id": 3, 
             "commonsId": 1, 
             "userId": 4, 
             "totalWealth": 9999, 
-            "numOfCows": 875
-            //,"averageCowHealth": 90.0
+            "numOfCows": 875, 
+            "averageCowHealth": 90.0
         }
     ], 
 
@@ -35,8 +35,8 @@ const leaderboardFixtures =
             "commonsId": 5, 
             "userId": 1, 
             "totalWealth": 1000000,
-            "numOfCows": 1000
-            //,"averageCowHealth": 68.0
+            "numOfCows": 1000, 
+            "averageCowHealth": 68.0
         }
     ], 
     
@@ -47,40 +47,40 @@ const leaderboardFixtures =
             "commonsId": 22, 
             "userId": 23, 
             "totalWealth": 150000,
-            "numOfCows": 1000
-            //,"averageCowHealth": 78.0
+            "numOfCows": 1000, 
+            "averageCowHealth": 78.0
         }, 
         {
             "id": 2, 
             "commonsId": 22, 
             "userId": 45, 
             "totalWealth": 1000,
-            "numOfCows": 56
-            //,"averageCowHealth": 100.0
+            "numOfCows": 56, 
+            "averageCowHealth": 100.0
         }, 
         {
             "id": 3, 
             "commonsId": 22, 
             "userId": 11, 
             "totalWealth": 500,
-            "numOfCows": 23
-            //,"averageCowHealth": 100.0
+            "numOfCows": 23, 
+            "averageCowHealth": 100.0
         }, 
         {
             "id": 4, 
             "commonsId": 22, 
             "userId": 21, 
             "totalWealth": 56700,
-            "numOfCows": 450
-            //,"averageCowHealth": 92.0
+            "numOfCows": 450, 
+            "averageCowHealth": 92.0
         }, 
         {
             "id": 5, 
             "commonsId": 22, 
             "userId": 9, 
             "totalWealth": 10000000,
-            "numOfCows": 1000000
-            //,"averageCowHealth": 45.0
+            "numOfCows": 1000000, 
+            "averageCowHealth": 45.0
         }
     ]
 }; 

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -1,0 +1,49 @@
+import React from "react";
+import OurTable from "main/components/OurTable";
+
+export default function LeaderboardTable({ userCommonsWithId }) {
+
+    // filteredCommons contains all UserCommons passed in the input parameter, but removes
+    // several unneeded headers, such as id and commonsId
+
+    const columns = [
+        {
+            Header:'ID',
+            accessor: 'id',
+        },
+        {
+            Header:'Commons ID',
+            accessor: 'commonsId',
+        },
+        {
+            Header:'Player ID',
+            accessor: 'userId',
+        },
+        {
+            Header:'Total Wealth',
+            accessor: row => String(row.totalWealth),
+            id: 'totalWealth'
+        },
+        {
+            Header:'Number of Cows',
+            accessor: 'numOfCows',
+        },
+        /*
+        {
+            Header:'Average Cow Health',
+            accessor: row => String(row.averageCowHealth),
+            id: 'averageCowHealth'
+        },
+        */
+    ];
+
+    const testid = "LeaderboardTable";
+
+    const columnsToDisplay = columns;
+    
+    return <OurTable
+        data={userCommonsWithId}
+        columns={columnsToDisplay}
+        testid={testid}
+    />;
+};

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -28,13 +28,6 @@ export default function LeaderboardTable({ userCommonsWithId }) {
             Header:'Number of Cows',
             accessor: 'numOfCows',
         },
-        /*
-        {
-            Header:'Average Cow Health',
-            accessor: row => String(row.averageCowHealth),
-            id: 'averageCowHealth'
-        },
-        */
     ];
 
     const testid = "LeaderboardTable";

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -3,9 +3,6 @@ import OurTable from "main/components/OurTable";
 
 export default function LeaderboardTable({ userCommonsWithId }) {
 
-    // filteredCommons contains all UserCommons passed in the input parameter, but removes
-    // several unneeded headers, such as id and commonsId
-
     const columns = [
         {
             Header:'ID',

--- a/frontend/src/stories/components/Leaderboard/LeaderboardTable.stories.js
+++ b/frontend/src/stories/components/Leaderboard/LeaderboardTable.stories.js
@@ -1,0 +1,3 @@
+import React from 'react'
+
+

--- a/frontend/src/stories/components/Leaderboard/LeaderboardTable.stories.js
+++ b/frontend/src/stories/components/Leaderboard/LeaderboardTable.stories.js
@@ -1,3 +1,38 @@
+import React from 'react'; 
 
+import LeaderboardTable from "main/components/Leaderboard/LeaderboardTable";
+import leaderboardFixtures from "fixtures/leaderboardFixtures"; 
 
+export default {
+    title: 'components/Leaderboard/LeaderboardTable',
+    component: LeaderboardTable
+};
 
+const Template = (args) => {
+    return (
+        <LeaderboardTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    leaderboard: []
+};
+
+export const OneEntry = Template.bind({}); 
+
+OneEntry.args = {
+    leaderboard: leaderboardFixtures.oneLeaderboardOneEntry
+}
+
+export const ThreeEntries = Template.bind({}); 
+
+ThreeEntries.args = {
+    leaderboard: leaderboardFixtures.oneLeaderboardThreeEntries
+}
+
+export const FiveEntries = Template.bind({});
+FiveEntries.args = {
+    leaderboard: leaderboardFixtures.oneLeaderboardFiveEntries
+}

--- a/frontend/src/stories/components/Leaderboard/LeaderboardTable.stories.js
+++ b/frontend/src/stories/components/Leaderboard/LeaderboardTable.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'; 
 
 import LeaderboardTable from "main/components/Leaderboard/LeaderboardTable";
-import leaderboardFixtures from "fixtures/leaderboardFixtures"; 
+import * as leaderboardFixtures from "fixtures/leaderboardFixtures.js"; 
 
 export default {
     title: 'components/Leaderboard/LeaderboardTable',
@@ -17,22 +17,22 @@ const Template = (args) => {
 export const Empty = Template.bind({});
 
 Empty.args = {
-    leaderboard: []
+    userCommonsWithId: []
 };
 
 export const OneEntry = Template.bind({}); 
 
 OneEntry.args = {
-    leaderboard: leaderboardFixtures.oneLeaderboardOneEntry
-}
+    userCommonsWithId: leaderboardFixtures.oneLeaderboardOneEntry
+};
 
 export const ThreeEntries = Template.bind({}); 
 
 ThreeEntries.args = {
-    leaderboard: leaderboardFixtures.oneLeaderboardThreeEntries
-}
+    userCommonsWithId: leaderboardFixtures.oneLeaderboardThreeEntries
+};
 
 export const FiveEntries = Template.bind({});
 FiveEntries.args = {
-    leaderboard: leaderboardFixtures.oneLeaderboardFiveEntries
-}
+    userCommonsWithId: leaderboardFixtures.oneLeaderboardFiveEntries
+};

--- a/frontend/src/stories/components/Leaderboard/LeaderboardTable.stories.js
+++ b/frontend/src/stories/components/Leaderboard/LeaderboardTable.stories.js
@@ -1,3 +1,3 @@
-import React from 'react'
+
 
 

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import LeaderboardTable from "main/components/Leaderboard/LeaderboardTable";
-import { leaderboardFixtures } from "fixtures/leaderboardFixtures";
+import * as leaderboardFixtures from "fixtures/leaderboardFixtures.js"; 
 
 const mockedNavigate = jest.fn();
 

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import LeaderboardTable from "main/components/Leaderboard/LeaderboardTable"
-import { leaderboardFixtures } from "fixtures/LeaderboardFixtures";
+import LeaderboardTable from "main/components/Leaderboard/LeaderboardTable";
+import { leaderboardFixtures } from "fixtures/leaderboardFixtures";
 
 const mockedNavigate = jest.fn();
 

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import LeaderboardTable from "main/components/Leaderboard/LeaderboardTable"
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { leaderboardFixtures } from "fixtures/LeaderboardFixtures";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("LeaderboardTable tests", () => {
+  const queryClient = new QueryClient();
+
+  test("renders without crashing for empty table with user not logged in", () => {
+    const currentUser = null;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LeaderboardTable userCommonsWithId={[]}/>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  });
+  test("renders without crashing for empty table for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LeaderboardTable userCommonsWithId={[]} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("renders without crashing for empty table for admin", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LeaderboardTable userCommonsWithId={[]}/>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  });
+
+  test("Has the expected column headers and content for adminUser", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LeaderboardTable userCommonsWithId={leaderboardFixtures.oneLeaderboardThreeEntries}/>
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ["ID", "Commons ID", "Player ID", "Total Wealth", "Number of Cows"];
+    const expectedFields = ["id", "commonsId", "userId", "totalWealth", "numOfCows"];
+    const testId = "LeaderboardTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("10000");
+  });
+});

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -2,7 +2,6 @@ import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import LeaderboardTable from "main/components/Leaderboard/LeaderboardTable"
-import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import { leaderboardFixtures } from "fixtures/LeaderboardFixtures";
 
 const mockedNavigate = jest.fn();
@@ -15,20 +14,7 @@ jest.mock('react-router-dom', () => ({
 describe("LeaderboardTable tests", () => {
   const queryClient = new QueryClient();
 
-  test("renders without crashing for empty table with user not logged in", () => {
-    const currentUser = null;
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <LeaderboardTable userCommonsWithId={[]}/>
-        </MemoryRouter>
-      </QueryClientProvider>
-    );
-  });
-  test("renders without crashing for empty table for ordinary user", () => {
-    const currentUser = currentUserFixtures.userOnly;
-
+  test("renders without crashing for empty table for any user", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -39,21 +25,7 @@ describe("LeaderboardTable tests", () => {
     );
   });
 
-  test("renders without crashing for empty table for admin", () => {
-    const currentUser = currentUserFixtures.adminUser;
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <LeaderboardTable userCommonsWithId={[]}/>
-        </MemoryRouter>
-      </QueryClientProvider>
-    );
-  });
-
-  test("Has the expected column headers and content for adminUser", () => {
-    const currentUser = currentUserFixtures.adminUser;
-
+  test("Has the expected column headers and content for any user", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -55,6 +55,19 @@ public class UserCommonsController extends ApiController {
     return userCommons;
   }
 
+  // Not sure what we should put for PreAuthorize.
+  // We need Admin to be able to call, but also if regular User visits Leaderboard and Admin has showLeaderboard set
+  // to true, then regular User should be able to call as well.
+  @ApiOperation(value = "Get all user commons with a specific commonsId")
+  @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
+  @GetMapping("/allWithCommonsId")
+  public Iterable<UserCommons> getUserCommonsByCommonsId(
+    @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
+      // we purposely don't check for a throw here, similar to UCSBDiningCommonsController
+      Iterable<UserCommons> userCommons = userCommonsRepository.findAllByCommonsId(commonsId);
+      return userCommons;
+  }
+
   @ApiOperation(value = "Get a user commons for current user")
   @PreAuthorize("hasRole('ROLE_USER')")
   @GetMapping("/forcurrentuser")

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -59,9 +59,9 @@ public class UserCommonsController extends ApiController {
   // We need Admin to be able to call, but also if regular User visits Leaderboard and Admin has showLeaderboard set
   // to true, then regular User should be able to call as well.
   @ApiOperation(value = "Get all user commons with a specific commonsId")
-  @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
-  @GetMapping("/allWithCommonsId")
-  public Iterable<UserCommons> getUserCommonsByCommonsId(
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/allwithcommonsid")
+  public Iterable<UserCommons> getAllUserCommonsByCommonsId(
     @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
       // we purposely don't check for a throw here, similar to UCSBDiningCommonsController
       Iterable<UserCommons> userCommons = userCommonsRepository.findAllByCommonsId(commonsId);

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
@@ -31,3 +31,4 @@ public class UserCommons {
   private int numOfCows;
 }
 
+

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
@@ -30,5 +30,3 @@ public class UserCommons {
 
   private int numOfCows;
 }
-
-

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/UserCommonsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/UserCommonsRepository.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.happiercows.repositories;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.repository.CrudRepository;
@@ -10,6 +11,7 @@ import edu.ucsb.cs156.happiercows.entities.UserCommons;
 @Repository
 public interface UserCommonsRepository extends CrudRepository<UserCommons, Long> {
     Optional<UserCommons> findByCommonsIdAndUserId(Long commonsId, Long userId );
+    Iterable<UserCommons> findAllByCommonsId(Long commonsId);
 
     void deleteAllByCommonsId(Long commonsId);
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -141,7 +141,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
     expectedCommons.addAll(Arrays.asList(dummyUserCommons(1), dummyUserCommons(2), dummyUserCommons(3)));
     when(userCommonsRepository.findAllByCommonsId(eq(1L))).thenReturn(expectedCommons);
 
-    MvcResult response = mockMvc.perform(get("/api/usercommons/allWithCommonsId?commonsId=1"))
+    MvcResult response = mockMvc.perform(get("/api/usercommons/allwithcommonsid?commonsId=1"))
         .andExpect(status().isOk()).andReturn();
 
     verify(userCommonsRepository, times(1)).findAllByCommonsId(eq(1L));
@@ -156,7 +156,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
     ArrayList<UserCommons> expectedCommons = new ArrayList<>();
     when(userCommonsRepository.findAllByCommonsId(eq(1L))).thenReturn(expectedCommons);
 
-    MvcResult response = mockMvc.perform(get("/api/usercommons/allWithCommonsId?commonsId=1"))
+    MvcResult response = mockMvc.perform(get("/api/usercommons/allwithcommonsid?commonsId=1"))
         .andExpect(status().isOk()).andReturn();
 
     verify(userCommonsRepository, times(1)).findAllByCommonsId(eq(1L));

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Optional;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -131,6 +132,37 @@ public class UserCommonsControllerTests extends ControllerTestCase {
     Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
     Map<String, Object> jsonResponse = responseToJson(response);
     assertEquals(expectedJson, jsonResponse);
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void test_getAllUserCommonsByCommonsId_some() throws Exception {
+    ArrayList<UserCommons> expectedCommons = new ArrayList<>();
+    expectedCommons.addAll(Arrays.asList(dummyUserCommons(1), dummyUserCommons(2), dummyUserCommons(3)));
+    when(userCommonsRepository.findAllByCommonsId(eq(1L))).thenReturn(expectedCommons);
+
+    MvcResult response = mockMvc.perform(get("/api/usercommons/allWithCommonsId?commonsId=1"))
+        .andExpect(status().isOk()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findAllByCommonsId(eq(1L));
+    String expectedJson = mapper.writeValueAsString(expectedCommons);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void test_getAllUserCommonsByCommonsId_none() throws Exception {
+    ArrayList<UserCommons> expectedCommons = new ArrayList<>();
+    when(userCommonsRepository.findAllByCommonsId(eq(1L))).thenReturn(expectedCommons);
+
+    MvcResult response = mockMvc.perform(get("/api/usercommons/allWithCommonsId?commonsId=1"))
+        .andExpect(status().isOk()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findAllByCommonsId(eq(1L));
+    String expectedJson = mapper.writeValueAsString(expectedCommons);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
   }
 
   @WithMockUser(roles = { "USER" })


### PR DESCRIPTION
Created the leaderboardFixtures with three types of leaderboards - one table with one entry, one table with three entries, and one table with 5 entries. Also created the .stories.js file to be able to display the leaderboard on Storybook. The Leaderboard and all three types of tables are visible in the Storybook. Closes issue #63 #64 

Note: This branch required two branches to be merged in order to get the functionality to work appropriately. The branches merged were: ap-leaderboard-fixtures and Richard-leaderboard-backend, 