### PR TITLE
Added SQL Query and backend API route created to get the total number of cows in a common

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -188,4 +188,23 @@ public class CommonsController extends ApiController {
     userCommonsRepository.deleteById(userCommons.getId());
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
+
+  // @ApiOperation("Sums the total cows in a commons")
+  // @PreAuthorize("hasRole('ROLE_USER')")
+  // @GetMapping("/{commonsId}")
+  // public ResponseEntity<String> sumCowsFromCommon(@PathVariable("commonsId") Long commonsId) throws Exception {
+
+  //   Commons commons = commonsRepository.findById(commonsId)
+  //       .orElseThrow(() -> new EntityNotFoundException(Commons.class, commonsId));
+
+
+  //   Optional<Integer> numberOfCows = commonsRepository.sumTotalCows(commonsId);
+
+  //   if (numberOfCows.isPresent()) {
+  //     String body = mapper.writeValueAsString(numberOfCows);
+  //     return ResponseEntity.ok().body(body);
+  //   } 
+  //   String body = mapper.writeValueAsString(0);
+  //   return ResponseEntity.ok().body(body);
+  // }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -203,7 +203,7 @@ public class CommonsController extends ApiController {
       return numberOfCows.get();
     } 
       
-    return new Integer(0);
+    return 0;
 
   }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -191,8 +192,8 @@ public class CommonsController extends ApiController {
 
   @ApiOperation("Sums the total cows in a commons")
   @PreAuthorize("hasRole('ROLE_USER')")
-  @GetMapping("/{commonsId}")
-  public ResponseEntity<String> sumCowsFromCommon(@PathVariable("commonsId") Long commonsId) throws Exception {
+  @GetMapping("/totalCows/{commonsId}")
+  public Integer sumCowsFromCommon(@PathVariable("commonsId") Long commonsId) throws Exception {
 
     Commons commons = commonsRepository.findById(commonsId)
         .orElseThrow(() -> new EntityNotFoundException(Commons.class, commonsId));
@@ -200,10 +201,10 @@ public class CommonsController extends ApiController {
     Optional<Integer> numberOfCows = commonsRepository.sumTotalCows(commonsId);
 
     if (numberOfCows.isPresent()) {
-      String body = mapper.writeValueAsString(numberOfCows);
-      return ResponseEntity.ok().body(body);
+      return numberOfCows.get();
     } 
-    String body = mapper.writeValueAsString(0);
-    return ResponseEntity.ok().body(body);
+      
+    return new Integer(0);
+
   }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -189,22 +189,21 @@ public class CommonsController extends ApiController {
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 
-  // @ApiOperation("Sums the total cows in a commons")
-  // @PreAuthorize("hasRole('ROLE_USER')")
-  // @GetMapping("/{commonsId}")
-  // public ResponseEntity<String> sumCowsFromCommon(@PathVariable("commonsId") Long commonsId) throws Exception {
+  @ApiOperation("Sums the total cows in a commons")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/{commonsId}")
+  public ResponseEntity<String> sumCowsFromCommon(@PathVariable("commonsId") Long commonsId) throws Exception {
 
-  //   Commons commons = commonsRepository.findById(commonsId)
-  //       .orElseThrow(() -> new EntityNotFoundException(Commons.class, commonsId));
+    Commons commons = commonsRepository.findById(commonsId)
+        .orElseThrow(() -> new EntityNotFoundException(Commons.class, commonsId));
 
+    Optional<Integer> numberOfCows = commonsRepository.sumTotalCows(commonsId);
 
-  //   Optional<Integer> numberOfCows = commonsRepository.sumTotalCows(commonsId);
-
-  //   if (numberOfCows.isPresent()) {
-  //     String body = mapper.writeValueAsString(numberOfCows);
-  //     return ResponseEntity.ok().body(body);
-  //   } 
-  //   String body = mapper.writeValueAsString(0);
-  //   return ResponseEntity.ok().body(body);
-  // }
+    if (numberOfCows.isPresent()) {
+      String body = mapper.writeValueAsString(numberOfCows);
+      return ResponseEntity.ok().body(body);
+    } 
+    String body = mapper.writeValueAsString(0);
+    return ResponseEntity.ok().body(body);
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonsRepository.java
@@ -4,11 +4,13 @@ import java.util.Optional;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;
 
 import edu.ucsb.cs156.happiercows.entities.Commons;
 
 
 @Repository
 public interface CommonsRepository extends CrudRepository<Commons, Long> {
-
+    @Query("SELECT sum(uc.numOfCows) from user_commons uc where uc.commonsId=:commonsId")
+    int sumTotalCows(long commonsId);
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonsRepository.java
@@ -11,6 +11,6 @@ import edu.ucsb.cs156.happiercows.entities.Commons;
 
 @Repository
 public interface CommonsRepository extends CrudRepository<Commons, Long> {
-    // @Query("SELECT sum(uc.numOfCows) from user_commons uc where uc.commonsId=:commonsId")
-    // Optional<Integer> sumTotalCows(Long commonsId);
+    @Query("SELECT sum(uc.numOfCows) from user_commons uc where uc.commonsId=:commonsId")
+    Optional<Integer> sumTotalCows(Long commonsId);
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonsRepository.java
@@ -11,6 +11,6 @@ import edu.ucsb.cs156.happiercows.entities.Commons;
 
 @Repository
 public interface CommonsRepository extends CrudRepository<Commons, Long> {
-    @Query("SELECT sum(uc.numOfCows) from user_commons uc where uc.commonsId=:commonsId")
-    int sumTotalCows(long commonsId);
+    // @Query("SELECT sum(uc.numOfCows) from user_commons uc where uc.commonsId=:commonsId")
+    // Optional<Integer> sumTotalCows(Long commonsId);
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -480,4 +480,47 @@ public class CommonsControllerTests extends ControllerTestCase {
       "org.springframework.web.util.NestedServletException: Request processing failed; nested exception is java.lang.Exception: UserCommons with commonsId=2 and userId=1 not found.");
     }
   }
+
+  // @WithMockUser(roles = {"USER"})
+  // @Test
+  // public void get_total_cows_from_commons() throws Exception {
+  //   Commons common = Commons.builder()
+  //     .name("TestCommons1")
+  //     .id(1L)
+  //     .build();
+
+  //   // List<UserCommons> expectedUserCommons = new ArrayList<Commons>();
+
+  //   // UserCommons uc1 = UserCommons.builder()
+  //   //     .id(16L)
+  //   //     .userId(1L)
+  //   //     .commonsId(1L)
+  //   //     .totalWealth(10)
+  //   //     .numOfCows(456)
+  //   //     .build();
+    
+  //   // UserCommons uc2 = UserCommons.builder()
+  //   //     .id(1L)
+  //   //     .userId(5L)
+  //   //     .commonsId(1L)
+  //   //     .totalWealth(45)
+  //   //     .numOfCows(91)
+  //   //     .build();
+
+  //   // expectedUserCommons.add(uc1);
+  //   // expectedUserCommons.add(uc2);
+  //   // when(expectedUserCommons.findAll()).thenReturn(expectedUserCommons);
+
+  //   when(commonsRepository.findById(1L)).thenReturn(Optional.of(common));
+  //   when(commonsRepository.sumTotalCows(1L)).thenReturn(547);
+
+  //   MvcResult response = mockMvc.perform(get("/api/commons/1").contentType("application/json"))
+  //       .andExpect(status().isOk()).andReturn();
+
+  //   verify(commonsRepository, times(1)).findById(1L);
+  //   verify(commonsRepository, times(1)).sumTotalCows(1L);
+
+  //   String responseString = response.getResponse().getContentAsString();
+  //   assertEquals(responseString, "547");
+  // }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -492,7 +492,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     when(commonsRepository.findById(1L)).thenReturn(Optional.of(common));
     when(commonsRepository.sumTotalCows(1L)).thenReturn(Optional.of(547));
 
-    MvcResult response = mockMvc.perform(get("/api/commons/1").contentType("application/json"))
+    MvcResult response = mockMvc.perform(get("/api/commons/totalCows/1").contentType("application/json"))
         .andExpect(status().isOk()).andReturn();
 
     verify(commonsRepository, times(1)).findById(1L);
@@ -513,7 +513,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     when(commonsRepository.findById(1L)).thenReturn(Optional.of(common));
     when(commonsRepository.sumTotalCows(1L)).thenReturn(Optional.empty());
 
-    MvcResult response = mockMvc.perform(get("/api/commons/1").contentType("application/json"))
+    MvcResult response = mockMvc.perform(get("/api/commons/totalCows/1").contentType("application/json"))
         .andExpect(status().isOk()).andReturn();
 
     verify(commonsRepository, times(1)).findById(1L);
@@ -532,7 +532,7 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     when(commonsRepository.findById(1L)).thenReturn(Optional.empty());
 
-    MvcResult response = mockMvc.perform(get("/api/commons/1").contentType("application/json"))
+    MvcResult response = mockMvc.perform(get("/api/commons/totalCows/1").contentType("application/json"))
         .andExpect(status().is(404)).andReturn();
 
     verify(commonsRepository, times(1)).findById(1L);


### PR DESCRIPTION
# Overview

Implemented SQL Query for the total number of cows in a common and backend API route is created to get total number of cows
- added SQP Query as a method `sumTotalCows` in `commonsRepository` 
- New endpoint/API route for `/api/commons/totalCows/{commonsId}` is added in `commonsController` to get the total cows in a common

# Issues Addressed

Closes #80

# Details

![image](https://user-images.githubusercontent.com/47654831/172031459-fa2b46ae-3f4e-4d74-a074-42b42a59e007.png)

# Other comments/suggestions
Might consider having the total number of cows as a field in the `commons` entity. So one call to get a commons will have also have a total cows field. Might save an API call to backend if a commons and its total cow number needs to both be fetched