### PR TITLE
Fixed spam "UserCommons with id X not found" bug

### DIFF
--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -50,12 +50,12 @@ export default function PlayPage() {
   // Stryker disable all 
   const { data: userCommonsProfits } =
     useBackend(
-      [`/api/profits/all/commons?userCommonsId=${commonsId}`],
+      [`/api/profits/all/forcommonsid?commonsId=${commonsId}`],
       {
         method: "GET",
-        url: "/api/profits/all/commons",
+        url: "/api/profits/all/forcommonsid",
         params: {
-          userCommonsId: commonsId
+          commonsId: commonsId
         }
       }
     );

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
@@ -79,7 +79,7 @@ public class ProfitsController extends ApiController {
         return profits;
     }
 
-    @ApiOperation(value = "Get all profits belonging to a user commons as a user")
+    @ApiOperation(value = "Get all profits belonging to a user commons as a user using userCommonsId")
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/all/commons")
     public Iterable<Profit> allProfitsByUserCommonsId(
@@ -96,7 +96,7 @@ public class ProfitsController extends ApiController {
         return profits;
     }
 
-    @ApiOperation(value = "Get all profits belonging to a user commons as a user")
+    @ApiOperation(value = "Get all profits belonging to a user commons as a user using commonsId")
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/all/forcommonsid")
     public Iterable<Profit> allProfitsByCommonsId(

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
@@ -96,6 +96,24 @@ public class ProfitsController extends ApiController {
         return profits;
     }
 
+    @ApiOperation(value = "Get all profits belonging to a user commons as a user")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all/forcommonsid")
+    public Iterable<Profit> allProfitsByCommonsId(
+            @ApiParam("commonsId") @RequestParam Long commonsId) {
+        Long userId = getCurrentUser().getUser().getId();
+
+        UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)
+            .orElseThrow(() -> new EntityNotFoundException(UserCommons.class, "commonsId", commonsId, "userId", userId));
+
+        if (userId != userCommons.getUserId())
+            throw new EntityNotFoundException(UserCommons.class, userCommons.getId());
+
+        Iterable<Profit> profits = profitRepository.findAllByUserCommonsId(userCommons.getId());
+
+        return profits;
+    }
+
     @ApiOperation(value = "Get all profits belonging to a user commons as an admin")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/admin/all/commons")

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
@@ -279,7 +279,7 @@ public class ProfitsControllerTests extends ControllerTestCase {
 
     Map<String, Object> json = responseToJson(response);
     assertEquals("EntityNotFoundException", json.get("type"));
-    assertEquals("UserCommons with commonId 2 and userId 1 not found", json.get("message"));
+    assertEquals("UserCommons with commonsId 2 and userId 1 not found", json.get("message"));
   }
 
   @WithMockUser(roles = { "ADMIN" })

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
@@ -279,7 +279,7 @@ public class ProfitsControllerTests extends ControllerTestCase {
 
     Map<String, Object> json = responseToJson(response);
     assertEquals("EntityNotFoundException", json.get("type"));
-    assertEquals("UserCommons with id commondId 2 and userId 1 not found", json.get("message"));
+    assertEquals("UserCommons with commondId 2 and userId 1 not found", json.get("message"));
   }
 
   @WithMockUser(roles = { "ADMIN" })

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
@@ -270,7 +270,7 @@ public class ProfitsControllerTests extends ControllerTestCase {
     assertEquals("UserCommons with id 1 not found", json.get("message"));
   }
 
-   @WithMockUser(roles = { "USER" })
+  @WithMockUser(roles = { "USER" })
   @Test
   public void get_profits_all_commons_nonexistent_with_commons_id() throws Exception {
     MvcResult response = mockMvc.perform(get("/api/profits/all/forcommonsid?commonsId=2").contentType("application/json")).andExpect(status().isNotFound()).andReturn();
@@ -279,7 +279,7 @@ public class ProfitsControllerTests extends ControllerTestCase {
 
     Map<String, Object> json = responseToJson(response);
     assertEquals("EntityNotFoundException", json.get("type"));
-    assertEquals("UserCommons with commondId 2 and userId 1 not found", json.get("message"));
+    assertEquals("UserCommons with commonId 2 and userId 1 not found", json.get("message"));
   }
 
   @WithMockUser(roles = { "ADMIN" })


### PR DESCRIPTION
# Overview

Fixed spam `UserCommons with id X not found` when loading up the PlayPage
- New backend api route for profit is created to fetch `userCommons` by the `commonsId` and `userId`
- PlayPage uses the new backend api route instead

# Issues Addressed

Close #36 

# Details
Before:
![image](https://user-images.githubusercontent.com/47654831/172078417-6102370c-5d4b-4810-9b81-67198c4228be.png)
After:
![image](https://user-images.githubusercontent.com/47654831/172079296-1eaeafc6-882f-44a0-8c95-6dbece213349.png)
